### PR TITLE
Update PB Name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 - **Version**:  1.0.1
 - **Certified**: Yes
 - **Publisher**: Fortinet
-- **Compatible Version**: FortiSOAR v7.2.0 and above
+- **Compatible Version**: FortiSOAR v7.2.0 and later
 - [Release Notes](./release_notes.md)
 
 # Overview
 
 The **Phishing Email Response** solution pack contains a set of investigation playbooks that help you respond to suspicious emails. It also includes a scenario that generates a demo alert of the type *Suspicious Email* and demonstrates the available actions.
 
-The use-case deals with investigation and containment procedures that come in effect when end-users report a suspicious email by sending it to a designated mailbox in any of the following formats:
+The use case deals with investigation and containment procedures that come into effect when end-users report a suspicious email by sending it to a designated mailbox in any of the following formats:
 
 - As an attachment in `.msg` format
 - As an attachment in `.eml` format
@@ -20,9 +20,9 @@ This solution pack, along with its included playbooks, investigates suspicious e
 - **Spoofing** - by checking sender and reply-to address
 - **Suspicious terms** - terms like bitcoin, free money, or free membership
 
-Moreover, you can manually upload emails in `.eml` or `.msg` format for investigation and enrichment of indicators.
+Moreover, you can manually upload emails in `.eml` or `.msg` format to investigate and enrich extracted indicators.
 
-Following is a demonstration video on how to use Phishing Email Response solution pack:
+Following is a demonstration video on how to use the Phishing Email Response solution pack:
 
 [![](./docs/res/phishing-email-response-thumbnail.png)](https://www.youtube.com/watch?v=Ch6yTGiES7I)
 **Video: Using Phishing Response Solution Pack**

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -1,34 +1,34 @@
 | [Home](../README.md) |
-|------------------------------------------------------------------------------------------------------------------|
-
+|----------------------|
 # Contents
 
 The **Phishing Email Response** solution pack contains the following resources.
 
 ## Global Variable
 
-| Name            | Description                                                                                                   |
-|:----------------|:--------------------------------------------------------------------------------------------------------------|
-| `Default_Email` | This global variable contains the email address which sends acknowledgement and other emails to the reporter. |
+| Name            | Description                                                                                                     |
+|:----------------|:----------------------------------------------------------------------------------------------------------------|
+| `Default_Email` | This global variable contains the email address which sends an acknowledgment and other emails to the reporter. |
 
 ## Record Set
 
-| Name     | Description                                                                         |
-|:---------|:------------------------------------------------------------------------------------|
-| Scenario | A simulation that helps you understand the *Phishing Email Response* solution pack by creating a demo phishing email alert. It then performs a set of actions to emulate the solution pack's behavior on receiving such alerts. |
+| Name     | Description                                                                                                                                                                                                          |
+|:---------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Scenario | A simulation that helps you understand the *Phishing Email Response* solution pack by creating a demo phishing email alert. Executing this scenario emulates this solution pack's behavior on receiving such alerts. |
 
 ## Playbook Collection
 
-| 02 - Use Case - Phishing Email Response |
-|:----------------------------------------|
+| 02 - Use Case - Phishing Email Response                                  |
+|:-------------------------------------------------------------------------|
 
-| Playbook Name                                            | Description                                                           |
-|:---------------------------------------------------------|:----------------------------------------------------------------------|
-| Investigate Suspicious Email                             | Investigates alerts of type *Suspicious Email*                        |
-| Generate Phishing Email Alert                            | Generates a Phishing Email alert                                      |
-| Email (Manual Upload) - Investigate                      | Extracts email metadata from an uploaded email file                   |
-| Email (Manual Attach) - File to Alert (Suspicious Email) | Attaches emails to alerts of type *Suspicious Email* and investigates |
-| Email (Manual Upload) - Extract Attachments              | Extracts attachments, creates indicators, and links to parent alert   |
-| Indicator (Type URL) - Get Reputation (Fortinet Sandbox) | Retrieves the reputation of indicators of type ‘URL’ using Fortinet FortiSandbox. |
 
->**Warning:** We recommend that you clone these playbooks before customizing to avoid loss of information while upgrading the solution pack.
+| Playbook Name                                                          | Description                                                                       |
+|:-----------------------------------------------------------------------|:----------------------------------------------------------------------------------|
+| Investigate Suspicious Email                                           | Investigates alerts of type *Suspicious Email*                                    |
+| Generate Phishing Email Alert                                          | Generates a Phishing Email alert                                                  |
+| Email (Manual Upload) - Investigate                                    | Extracts email metadata from an uploaded email file                               |
+| Email (Manual Attach) - File to Alert (Suspicious Email)               | Attaches emails to alerts of type *Suspicious Email* and investigates             |
+| Email (Manual Upload) - Extract Attachments                            | Extracts attachments, creates indicators, and links to parent alert               |
+| URL > FortiSandbox > Enrichment<sup>New</sup>                          | Retrieves the reputation of indicators of type 'URL' using Fortinet FortiSandbox. |
+
+>**Warning:** We recommend you clone these playbooks before customizing to avoid information loss while upgrading the solution pack.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,27 +1,26 @@
 | [Home](../README.md) |
 |----------------------|
-
 # Installation
 
 1. To install a solution pack, click **Content Hub** > **Discover**.   
 2. From the list of solution pack that appears, search for and select **Phishing Email Response**.    
 3. Click the **Phishing Email Response** solution pack card.   
-4. Click the **Install** button on the bottom to begin installation.
+4. Click the **Install** button on the bottom to begin the installation.
 
 ## Prerequisites
 
 The **Phishing Email Response** solution pack depends on the following solution packs that are installed automatically &ndash; if not already installed.
 
-| **Solution Pack Name** | **Purpose**                                              |
-|:-----------------------|:---------------------------------------------------------|
-| SOAR Framework         | Required for Incident Response modules                   |
-| SOC Simulator          | Required for Scenario Module and SOC Simulator connector |
+| Solution Pack Name | Purpose                                                  |
+|:-------------------|:---------------------------------------------------------|
+| SOAR Framework     | Required for Incident Response modules                   |
+| SOC Simulator      | Required for Scenario Module and SOC Simulator connector |
 
 # Configuration
 
-For optimal performance of **Phishing Email Response** solution pack, you must configure:
+For optimal performance of the **Phishing Email Response** solution pack, you must configure:
 
-- Threat intelligence connectors to enrich context of a given indicator
+- Threat intelligence connectors to enrich the context of a given indicator
     - To configure and use the VirusTotal connector as a source of threat intelligence, refer to [Configuring Virus Total](https://docs.fortinet.com/document/fortisoar/2.1.0/virustotal/166/virustotal-v2-1-0#Configuration_parameters)
-- An email ingestion process to periodically read email from a designated inbox and convert them into alerts in FortiSOAR
+- An email ingestion process to periodically read emails from a designated inbox and convert them into alerts in FortiSOAR
     - To configure and use the Microsoft Exchange connector for email ingestion, refer to [Configuring Exchange Connector](https://docs.fortinet.com/document/fortisoar/3.4.0/exchange/1/exchange-v3-4-0#Configuring_the_connector)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,22 +1,21 @@
 | [Home](../README.md) |
-|------------------------------------------------------------------------------------------------------------------|
-
+|----------------------|
 # Usage
 
 Refer to [Simulate Scenario documentation](https://github.com/fortinet-fortisoar/solution-pack-soc-simulator/blob/develop/docs/usage.md) to understand how to simulate and reset scenarios.
 
 To understand the process FortiSOAR follows to respond to phishing emails, we have included a scenario &mdash; **Phishing Email Response** with this solution pack. 
 
-This solution pack includes a playbook that you can launch manually from the alerts page. This playbook performs following automated tasks:
+This solution pack includes a playbook that you can launch manually from the alerts page. This playbook performs the following automated tasks:
 
-- Send an email acknowledging the reporter, of the suspicious email, about ongoing investigation 
+- Send an email acknowledging the reporter, of the suspicious email, about the ongoing investigation 
 - Perform spoofing and SPF checks
-- Check for a particular keyword (configurable in playbook)
-- If URL indicators are found, it prompts user to mark this phishing attempt as **Drive by Download**. User gets more information about URLs
+- Check for a particular keyword (configurable in the playbook)
+- If indicators of type URL are found, it prompts the user to mark this phishing attempt as **Drive by Download**. The user gets more information about URLs
 - User is prompted to review and receives a suggestion to block malicious indicators
-- Playbook finally sends out a message, to reporter of the suspicious email, with an investigation summary
+- Playbook finally sends out a message, to the reporter of the suspicious email, with an investigation summary
 
-Refer to the sections *Phishing Email Scenario* and *Manual Email Upload* to understand the how this solution pack's automation addresses your needs.
+Refer to the sections *Phishing Email Scenario* and *Manual Email Upload* to understand how this solution pack's automation addresses your needs.
 
 ## Phishing Email Scenario
 This scenario generates an example alert of type *Suspicious Email*.
@@ -28,14 +27,14 @@ Navigate to the demo alert and note the following:
 
 ## Manual Email Upload
 
-This section addresses the requirement where an email has to be uploaded manually for further investigation. An alert of type *Suspicious Email* must be present for the **Execute** button to display the playbook &ndash; **Attach Email** &ndash; from the playbook collection **02 - Use Case - Phishing Email Response**.
+This section addresses the requirement of an email that has to be manually uploaded for further investigation. An alert of type *Suspicious Email* must be present for the **Execute** button to display the playbook &ndash; **Attach Email** &ndash; from the playbook collection **02 - Use Case - Phishing Email Response**.
 
 When executed, this playbook prompts you to attach an email file in `.eml` or `.msg` format, to the alert.
 
 >**NOTE**: To see this playbook **Attach Email** in action, first create an alert of type *Suspicious Email*.
 
-The playbook, on creation of the alert, extracts metadata from the uploaded email file and maps that metadata with alerts' fields.
+When executed, this playbook prompts you to attach an email file in `.eml` or `.msg` format, to the alert.
 
 As soon as the upload is complete, the enrichment process starts. A notification informs that the indicators are being enriched. Once the enrichment completes, navigate to generated alert and note the following:
 - Attached  Email, if it contains an attachment, its extracted and then correlated as an indicator 
-- Alert fields are mapped with information from email, such as sender email Id, reporter email Id, and attachment &ndash; if any
+- Alert fields are mapped with information from the email, such as sender email Id, reporter email Id, and attachment &ndash; if any

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,3 @@
 # What's New
 
-- Added new "Indicator (Type URL) - Get Reputation (Fortinet FortiSandbox)" playbook that retrives reputation for URL type indicator using Fortinet FortiSandbox
+- Added a new playbook **URL > FortiSandbox > Enrichment** that retrieves reputation for indicators of type URL using Fortinet FortiSandbox


### PR DESCRIPTION
- In the recent changes in SP, we have replaced the playbook *Indicator (Type URL) - Get Reputation (Fortinet FortiSandbox)* with another playbook i.e. **URL > FortiSandbox > Enrichment**
- Hence updated the playbook name to `URL > FortiSandbox > Enrichment` in **content.md** as well as in **release_notes.md**

**Note:-** The previous doc changes PR - #28  was checked in to develop branch. In this PR checking in the same documents into the release/1.0.1 branch after doing the above-mentioned changes