### PR TITLE
QA Bug Fix

### DIFF
--- a/info.json
+++ b/info.json
@@ -20,7 +20,7 @@
             "minVersion": null
         }
     ],
-    "prerequisite": null,
+    "prerequisite": "- Configure the Fortinet FortiSandbox Connector",
     "certified": "true",
     "publisher": "Fortinet",
     "description": "Phishing Email Response Solution Pack is designed to provide a set of investigation and utility playbooks to respond to suspicous emails. These emails are typically reported by employees in the organization (sent to a SOC common email inbox).",

--- a/playbooks/02 - Use Case - Phishing Email Response/Email (Manual Upload) - Investigate.json
+++ b/playbooks/02 - Use Case - Phishing Email Response/Email (Manual Upload) - Investigate.json
@@ -90,7 +90,8 @@
                 },
                 "apply_async": false,
                 "step_variables": [],
-                "workflowReference": "\/api\/3\/workflows\/eb230ee2-e402-4327-8dba-1982c84ea1c1"
+                "pass_input_record": true,
+                "workflowReference": "\/api\/3\/workflows\/bff221c6-1a9b-4486-8180-6841e7a59f34"
             },
             "status": null,
             "top": "1110",


### PR DESCRIPTION
Mantis#0863179 - Playbook "Email (Manual Upload) - Investigate" is failing
- The IRI of the child playbook "03 - Enrich > Extract Indicators" IRI got changed SOAR Framework v2.0.0 onwards
- so link was broken for this playbook causing to playbook execution to fail
- Validated that "Email (Manual Upload) - Investigate" working correctly

Mantis#0862800 - Info.json update
- Added prerequisite instruction in info.json