### PR TITLE
BugFixes-1

### DIFF
--- a/info.json
+++ b/info.json
@@ -20,7 +20,7 @@
             "minVersion": null
         }
     ],
-    "prerequisite": "- Configure the Fortinet FortiSandbox Connector",
+    "prerequisite": "* Configure the Exchange connector to ingest emails\n* Configure the Virustotal and Fortinet FortiSandbox connectors to enrich indicators",
     "certified": "true",
     "publisher": "Fortinet",
     "description": "Phishing Email Response Solution Pack is designed to provide a set of investigation and utility playbooks to respond to suspicous emails. These emails are typically reported by employees in the organization (sent to a SOC common email inbox).",

--- a/playbooks/02 - Use Case - Phishing Email Response/Investigate Suspicious Email.json
+++ b/playbooks/02 - Use Case - Phishing Email Response/Investigate Suspicious Email.json
@@ -517,22 +517,15 @@
                                 "operator": "eq"
                             },
                             {
-                                "type": "primitive",
-                                "field": "source",
-                                "value": "Symantec Email.Cloud",
-                                "operator": "neq",
-                                "_operator": "neq"
-                            },
-                            {
                                 "type": "object",
                                 "field": "status",
-                                "value": "\/api\/3\/picklists\/7de816ff-7140-4ee5-bd05-93ce22002146",
+                                "value": "\/api\/3\/picklists\/fac53e73-8d16-4189-98d5-95fbd1555232",
                                 "_value": {
-                                    "@id": "\/api\/3\/picklists\/7de816ff-7140-4ee5-bd05-93ce22002146",
-                                    "display": "Open",
-                                    "itemValue": "Open"
+                                    "@id": "\/api\/3\/picklists\/fac53e73-8d16-4189-98d5-95fbd1555232",
+                                    "display": "Closed",
+                                    "itemValue": "Closed"
                                 },
-                                "operator": "eq"
+                                "operator": "neq"
                             }
                         ]
                     }

--- a/playbooks/02 - Use Case - Phishing Email Response/URL > Remote Screenshot > Create and Link Attachment.json
+++ b/playbooks/02 - Use Case - Phishing Email Response/URL > Remote Screenshot > Create and Link Attachment.json
@@ -145,6 +145,7 @@
             "description": null,
             "arguments": {
                 "route": "e4cb71e9-fa54-4844-ba87-325569f9bb8e",
+                "title": "Get URL Screenshot",
                 "resources": [
                     "alerts"
                 ],

--- a/playbooks/02 - Use Case - Phishing Email Response/URL > Remote Screenshot > Create and Link Attachment.json
+++ b/playbooks/02 - Use Case - Phishing Email Response/URL > Remote Screenshot > Create and Link Attachment.json
@@ -1,0 +1,275 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "URL > Remote Screenshot > Create and Link Attachment",
+    "aliasName": null,
+    "tag": null,
+    "description": "Generates and links attachment records for all the URLs associated with the alert",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/3cb90b29-1258-415c-8f4c-967296bccb15",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/b3f4993c-22f9-424e-8dd8-b1d2294b7df5",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "alertIRI": "{{vars.input.records[0]['@id']}}",
+                "alertUUID": "{{vars.input.records[0].uuid}}"
+            },
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "72872980-7512-4335-b95d-eb6dead1e7ff"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Attachment IRIs",
+            "description": null,
+            "arguments": {
+                "attachmentIRIList": "{{ vars.steps.Get_URL_Screenshot | json_query(\"[? attachmentIRI != None].attachmentIRI\") }}"
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "89fa2833-fcd1-4693-8092-fc261072c693"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Related URL Indicators",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "alerts.uuid",
+                            "value": "{{vars.alertUUID}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "object",
+                            "field": "typeofindicator",
+                            "value": "\/api\/3\/picklists\/353a37b4-3eeb-43ee-aac6-64806422cfec",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/353a37b4-3eeb-43ee-aac6-64806422cfec",
+                                "itemValue": "URL"
+                            },
+                            "operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "value"
+                    ]
+                },
+                "module": "indicators?$limit=5000&$relationships=true&$fsr_max_relation_count=100",
+                "checkboxFields": true,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "cba16a0f-f951-472d-990e-6db8dd8a041d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get URL Screenshot",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Get_Related_URL_Indicators}}",
+                    "__bulk": false,
+                    "parallel": true,
+                    "condition": ""
+                },
+                "arguments": {
+                    "url_value": "{{vars.item.value}}"
+                },
+                "apply_async": false,
+                "step_variables": [],
+                "pass_parent_env": false,
+                "pass_input_record": false,
+                "workflowReference": "\/api\/3\/workflows\/01acd03c-aaf1-4a79-b0b5-bddeb3a434a8"
+            },
+            "status": null,
+            "top": "435",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "5d4fe1e2-61bf-4a7c-8a30-73e3f900a236"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Link Screenshot Attachments to Alert",
+            "description": null,
+            "arguments": {
+                "when": "{{vars.attachmentIRIList | length > 0}}",
+                "resource": {
+                    "__link": {
+                        "attachments": "{{vars.attachmentIRIList}}"
+                    }
+                },
+                "operation": "Append",
+                "collection": "{{vars.alertIRI}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/alerts",
+                "fieldOperation": [],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "a636af47-b974-45c5-a4fd-1fa025f4873f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "route": "e4cb71e9-fa54-4844-ba87-325569f9bb8e",
+                "resources": [
+                    "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                    "input": {
+                        "params": [],
+                        "records": "{{vars.input.records}}"
+                    }
+                },
+                "displayConditions": {
+                    "alerts": {
+                        "sort": [],
+                        "limit": 30,
+                        "logic": "AND",
+                        "filters": [
+                            {
+                                "type": "object",
+                                "field": "status",
+                                "value": "\/api\/3\/picklists\/fac53e73-8d16-4189-98d5-95fbd1555232",
+                                "_value": {
+                                    "@id": "\/api\/3\/picklists\/fac53e73-8d16-4189-98d5-95fbd1555232",
+                                    "itemValue": "Closed"
+                                },
+                                "operator": "neq"
+                            },
+                            {
+                                "logic": "OR",
+                                "filters": [
+                                    {
+                                        "type": "object",
+                                        "field": "type",
+                                        "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                        "_value": {
+                                            "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                            "itemValue": "Phishing"
+                                        },
+                                        "operator": "eq"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "field": "type",
+                                        "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                        "_value": {
+                                            "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                            "itemValue": "Suspicious Email"
+                                        },
+                                        "operator": "eq"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": false,
+                "singleRecordExecution": true
+            },
+            "status": null,
+            "top": "30",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+            "group": null,
+            "uuid": "b3f4993c-22f9-424e-8dd8-b1d2294b7df5"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Get Related URL Indicators",
+            "targetStep": "\/api\/3\/workflow_steps\/cba16a0f-f951-472d-990e-6db8dd8a041d",
+            "sourceStep": "\/api\/3\/workflow_steps\/72872980-7512-4335-b95d-eb6dead1e7ff",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "41b3e6cd-338d-41d9-b721-4b6eb9ae824d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Attachment IRIs -> Link Screenshot Attachments to Alert",
+            "targetStep": "\/api\/3\/workflow_steps\/a636af47-b974-45c5-a4fd-1fa025f4873f",
+            "sourceStep": "\/api\/3\/workflow_steps\/89fa2833-fcd1-4693-8092-fc261072c693",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e34bb34c-ec06-4261-8c79-97024f755418"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Related URL Indicators -> Get URL Screenshot",
+            "targetStep": "\/api\/3\/workflow_steps\/5d4fe1e2-61bf-4a7c-8a30-73e3f900a236",
+            "sourceStep": "\/api\/3\/workflow_steps\/cba16a0f-f951-472d-990e-6db8dd8a041d",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "7bb452b2-2b7c-4454-b768-fc613e9e50a9"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get URL Screenshot -> Get Attachment IRIs",
+            "targetStep": "\/api\/3\/workflow_steps\/89fa2833-fcd1-4693-8092-fc261072c693",
+            "sourceStep": "\/api\/3\/workflow_steps\/5d4fe1e2-61bf-4a7c-8a30-73e3f900a236",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "52f1f8b4-dc51-438a-b50c-bb1ecd89caa2"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/72872980-7512-4335-b95d-eb6dead1e7ff",
+            "sourceStep": "\/api\/3\/workflow_steps\/b3f4993c-22f9-424e-8dd8-b1d2294b7df5",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "3ef4d9c0-4d57-471f-a565-b87b25da21b2"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "uuid": "8574d59b-bedf-4c8d-be31-b14c7595c603",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "ManualTrigger"
+    ]
+}

--- a/playbooks/02 - Use Case - Phishing Email Response/URL > Remote Screenshot > Get URL Screenshot.json
+++ b/playbooks/02 - Use Case - Phishing Email Response/URL > Remote Screenshot > Get URL Screenshot.json
@@ -1,0 +1,112 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "URL > Remote Screenshot > Get URL Screenshot",
+    "aliasName": null,
+    "tag": null,
+    "description": "Retrieves a screenshot of the the given URL",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [
+        "url_value"
+    ],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/3cb90b29-1258-415c-8f4c-967296bccb15",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/e3cc11a0-32a0-4179-b7c3-fc65b665db08",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Get URL Screenshot",
+            "description": null,
+            "arguments": {
+                "name": "Remote Screenshot",
+                "config": "4cd99388-800a-46d0-9d05-c76da8b6185c",
+                "params": {
+                    "url": "{{ vars.input.params['url_value'] }}",
+                    "screenshot_name": "{{ vars.input.params['url_value'] | urlsplit('hostname') }}",
+                    "screenshot_size": "Full Screenshot",
+                    "create_attachment": true
+                },
+                "version": "1.0.0",
+                "connector": "screenshot",
+                "operation": "screenshot_url",
+                "ignore_errors": true,
+                "operationTitle": "Screenshot URL",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "469dc2e9-5950-4397-a63d-474abb93e5ef"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "step_variables": {
+                    "input": {
+                        "params": []
+                    }
+                }
+            },
+            "status": null,
+            "top": "30",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+            "group": null,
+            "uuid": "e3cc11a0-32a0-4179-b7c3-fc65b665db08"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Step Result",
+            "description": null,
+            "arguments": {
+                "attachmentIRI": "{{vars.steps.Get_URL_Screenshot.data['@id'] or None}}"
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "bec0780e-9453-473a-8270-86c88ec47654"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get URL Screenshot -> Step Result",
+            "targetStep": "\/api\/3\/workflow_steps\/bec0780e-9453-473a-8270-86c88ec47654",
+            "sourceStep": "\/api\/3\/workflow_steps\/469dc2e9-5950-4397-a63d-474abb93e5ef",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "c2b43429-ac4e-4f8a-8774-b913b0e1cc1f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Get URL Screenshot",
+            "targetStep": "\/api\/3\/workflow_steps\/469dc2e9-5950-4397-a63d-474abb93e5ef",
+            "sourceStep": "\/api\/3\/workflow_steps\/e3cc11a0-32a0-4179-b7c3-fc65b665db08",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "87f63b62-8f80-4bb4-bc9d-2895c193a296"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "uuid": "01acd03c-aaf1-4a79-b0b5-bddeb3a434a8",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "Referenced"
+    ]
+}

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,3 @@
 # What's New
 
-- Added a new playbook **URL > FortiSandbox > Enrichment** that retrieves reputation for indicators of type URL using Fortinet FortiSandbox
-- SOAR Framework v2.0.0 and later is now one of the prerequisites to installing this solution pack
+- The playbook "Investigate Suspicious Email" will be triggered for unresolved "Suspicious Email" type alerts

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,3 @@
 # What's New
 
-- The playbook "Investigate Suspicious Email" will be triggered for unresolved "Suspicious Email" type alerts
+- The "Investigate Suspicious Email" playbook will only be visible and executable for unresolved alerts of the "Suspicious Email" type.


### PR DESCRIPTION
> Mantis#0924237
- Validated that the playbook "Investigate Suspicious Email" is now visible for unresolved "Suspicious Email" type alerts
- Validated that the visibility condition "source != Symantec Email.cloud" for the playbook "Investigate Suspicious Email" has been removed

> Mantis#0872333 - Need to rephrase instructions from Phishing Email Response
- Validated that instruction for solution pac has been rephrased as below
   - Configure the Exchange connector to ingest emails
   - Configure the Virustotal and Fortinet FortiSandbox connectors to enrich indicators

> Mantis#0924229 - Add playbook to retrieve URL screenshot
- Validated that URL screenshot has been retrieved for all the URLs associated with the  alert
