### PR TITLE
Modified Playbooks

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,10 +12,12 @@ This solution pack includes a playbook that you can launch manually from the ale
 - Perform spoofing and SPF checks
 - Check for a particular keyword (configurable in the playbook)
 - If indicators of type URL are found, it prompts the user to mark this phishing attempt as **Drive by Download**. The user gets more information about URLs
+- User is prompted to review provided investigation summary to determine if the alert is a valid phishing alert or a false positive.
 - User is prompted to review and receives a suggestion to block malicious indicators
-- Playbook finally sends out a message, to the reporter of the suspicious email, with an investigation summary
+- Sends out a message, to the reporter of the suspicious email, with an investigation summary
+- Playbook finally prompts user to either Continue with investigation keeping alert open or close the alert
 
-Refer to the sections *Phishing Email Scenario* and *Manual Email Upload* to understand how this solution pack's automation addresses your needs.
+Refer to the sections *Phishing Email Scenario*, *Get URL Screenshots* and *Manual Email Upload* to understand how this solution pack's automation addresses your needs.
 
 ## Phishing Email Scenario
 This scenario generates an example alert of type *Suspicious Email*.
@@ -38,6 +40,14 @@ When executed, this playbook prompts you to attach an email file in `.eml` or `.
 As soon as the upload is complete, the enrichment process starts. A notification informs that the indicators are being enriched. Once the enrichment completes, navigate to generated alert and note the following:
 - Attached  Email, if it contains an attachment, its extracted and then correlated as an indicator 
 - Alert fields are mapped with information from the email, such as sender email Id, reporter email Id, and attachment &ndash; if any
+
+## Get URLs Screenshots
+This section addresses the functionality to capture screenshot of the URLs that correlated to the alert of type *Suspicious Email*
+
+To execute this playbook, click on the **Execute** button and select `Get URL Screenshot`. 
+- This will capture screenshot of all the URLs indicators associated with the alert using `Remote Screenshot`. 
+- The screenshot will be saved as `Attachment` records and get correlated to the alert. Also the comment will be added to collaboration panel listing links of all the Screenshot attachments
+>**NOTE**: We recommend setting up the Remote Screenshot connector on the **agent** to securely access URLs.
 
 # Next Steps
 | [Installation](./setup.md#installation) | [Configuration](./setup.md#configuration) | [Contents](./contents.md) |

--- a/playbooks/02 - Use Case - Phishing Email Response/Investigate Suspicious Email.json
+++ b/playbooks/02 - Use Case - Phishing Email Response/Investigate Suspicious Email.json
@@ -63,7 +63,7 @@
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "alerts": "{{vars.input.records[0]['@id']}}",
                     "people": [],
-                    "content": "<p><span style=\"background: #2aba42; color: #ffffff; padding: 2px 7px;\" class=\"badge badge-pill badge-danger\"> No Spoofing<\/span> attempt identified<\/p>",
+                    "content": "<p><span class=\"badge badge-pill badge-danger\" style=\"background: #2aba42; color: #ffffff; padding: 2px 7px;\"> No Spoofing<\/span> attempt identified<\/p>",
                     "__replace": "",
                     "isImportant": false,
                     "peopleUpdated": false
@@ -94,7 +94,7 @@
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "alerts": "['{{vars.input.records[0]['@id']}}']",
                     "people": [],
-                    "content": "<p>{% if vars.SPF_Record | length == 0 -%}SPF check <span style=\"background: #FFFF00; color: #000000; padding: 2px 7px;\" class=\"badge badge-pill badge-danger\"><strong>Not Found</strong></span></p>\n<p>{% else -%}{% if vars.Not_Permitted_IPs_for_SPF_Fail | length != 0 -%}</p>\n<p>SPF check <span style=\"background: #FF0000; color: #ffffff; padding: 2px 7px;\" class=\"badge badge-pill badge-danger\"><strong>Failed</strong></span> due to non-permitted IP(s)</p>\n<p>&nbsp;</p>\n<p><strong>{% for ip in [vars.Not_Permitted_IPs_for_SPF_Fail] -%}IP: {{ ip }}{% endfor -%}</strong></p>\n<p>{% elif vars.Not_Permitted_IPs_for_SPF_SoftFail | length != 0 -%}</p>\n<p>SPF check <span style=\"background: #E67E23; color: #ffffff; padding: 2px 7px;\" class=\"badge badge-pill badge-danger\"><strong>Soft Failed</strong></span> due to non-permitted IP(s)</p>\n<p>&nbsp;</p>\n<p><strong>{% for ip in [vars.Not_Permitted_IPs_for_SPF_SoftFail] -%}IP: {{ ip }}{% endfor -%}</strong></p>\n<p>{% else -%}SPF check <span style=\"background: #2aba42; color: #ffffff; padding: 2px 7px;\" class=\"badge badge-pill badge-danger\"> Passed</span></p>\n<p>{% endif -%}{% endif %}</p>",
+                    "content": "<p>{% if vars.SPF_Record | length == 0 -%}SPF check <span class=\"badge badge-pill badge-danger\" style=\"background: #dbc030; color: #000000; padding: 2px 7px;\"><strong>Not Found<\/strong><\/span><\/p>\n<p>{% else -%}{% if vars.Not_Permitted_IPs_for_SPF_Fail | length != 0 -%}<\/p>\n<p>SPF check <span class=\"badge badge-pill badge-danger\" style=\"background: #FF0000; color: #ffffff; padding: 2px 7px;\"><strong>Failed<\/strong><\/span> due to non-permitted IP(s)<\/p>\n<p>&nbsp;<\/p>\n<p><strong>{% for ip in [vars.Not_Permitted_IPs_for_SPF_Fail] -%}IP: {{ ip }}{% endfor -%}<\/strong><\/p>\n<p>{% elif vars.Not_Permitted_IPs_for_SPF_SoftFail | length != 0 -%}<\/p>\n<p>SPF check <span class=\"badge badge-pill badge-danger\" style=\"background: #ba6204; color: #ffffff; padding: 2px 7px;\"><strong>Soft Failed<\/strong><\/span> due to non-permitted IP(s)<\/p>\n<p>&nbsp;<\/p>\n<p><strong>{% for ip in [vars.Not_Permitted_IPs_for_SPF_SoftFail] -%}IP: {{ ip }}{% endfor -%}<\/strong><\/p>\n<p>{% else -%}SPF check <span class=\"badge badge-pill badge-danger\" style=\"background: #2aba42; color: #ffffff; padding: 2px 7px;\"> Passed<\/span><\/p>\n<p>{% endif -%}{% endif %}<\/p>",
                     "__replace": "",
                     "isImportant": false,
                     "peopleUpdated": false
@@ -107,7 +107,7 @@
                     "recordTags": "Overwrite"
                 },
                 "step_variables": {
-                    "spf_check_message": "{% if vars.SPF_Record | length == 0 -%}SPF check <span class=\"badge badge-pill badge-danger\" style=\"background: #FFFF00; color: #000000; padding: 1px 7px;\"><span style=\"background-color: #ffff00;\"> Not Found<br><\/span><\/span>{% else -%}{% if vars.Not_Permitted_IPs_for_SPF_Fail | length != 0 -%} SPF check <span class=\"badge badge-pill badge-danger\" style=\"background: #FF0000; color: #ffffff; padding: 1px 7px;\"><span style=\"background-color: #ff0000;\"> Failed <br><\/span><\/span> due to non-permitted IP(s) {% elif vars.Not_Permitted_IPs_for_SPF_SoftFail | length != 0 -%} SPF check <span class=\"badge badge-pill badge-danger\" style=\"background: #E67E23; color: #ffffff; padding: 1px 7px;\"> Soft Failed <\/span> due to non-permitted IP(s) {% else -%} SPF check <span class=\"badge badge-pill badge-danger\" style=\"background: #2aba42; color: #ffffff; padding: 1px 7px;\"> Passed<\/span>{% endif -%}{% endif %}"
+                    "spf_check_message": "{% if vars.SPF_Record | length == 0 -%}SPF(Sender Policy Framework) check <span class=\"badge badge-pill badge-danger\" style=\"background: #FFFF00; color: #000000; padding: 1px 7px;\"><span style=\"background-color: #ffff00;\"> Not Found<br><\/span><\/span>{% else -%}{% if vars.Not_Permitted_IPs_for_SPF_Fail | length != 0 -%} SPF (Sender Policy Framework) check <span class=\"badge badge-pill badge-danger\" style=\"background: #FF0000; color: #ffffff; padding: 1px 7px;\"><span style=\"background-color: #ff0000;\"> Failed <br><\/span><\/span> due to non-permitted IP(s) {% elif vars.Not_Permitted_IPs_for_SPF_SoftFail | length != 0 -%} SPF (Sender Policy Framework) check <span class=\"badge badge-pill badge-danger\" style=\"background: #ba6204; color: #ffffff; padding: 1px 7px;\"> Soft Failed <\/span> due to non-permitted IP(s) {% else -%} SPF (Sender Policy Framework) check <span class=\"badge badge-pill badge-danger\" style=\"background: #2aba42; color: #ffffff; padding: 1px 7px;\"> Passed<\/span>{% endif -%}{% endif %}"
                 }
             },
             "status": null,
@@ -158,7 +158,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "{{vars.input.records[0].tenant['@id']}}",
-                    "content": "<p>Sender email address '{{vars.sender_email_address}}' do not match with the Return Path '{{vars.sender_return_path}}'.<\/p>\n<p>- Tagging alert as <strong><span class=\"badge badge-pill badge-danger\" style=\"background: #ba6204; color: #fff;\">Spoofing<\/span><\/strong>.<\/p>",
+                    "content": "<p>Sender email address '{{vars.sender_email_address}}' do not match with the Return Path '{{vars.sender_return_path}}'.<\/p>\n<p>- Tagging alert as <strong><span class=\"badge badge-pill badge-danger\" style=\"background: #ba6204; color: #fff; padding: 2px 7px;\">Spoofing<\/span><\/strong>.<\/p>",
                     "records": "",
                     "parentstepid": "\/api\/3\/workflow_steps\/8c142bf0-bc97-4683-85da-3076748e060a"
                 },
@@ -331,13 +331,23 @@
                                 "name": "reason",
                                 "type": "string",
                                 "label": "Reason",
+                                "title": "Text Area",
+                                "usable": false,
                                 "tooltip": "",
                                 "dataType": "text",
-                                "formType": "text",
+                                "formType": "textarea",
                                 "required": false,
                                 "_expanded": true,
-                                "defaultValue": "",
-                                "_previousName": "",
+                                "mmdUpdate": false,
+                                "collection": false,
+                                "searchable": false,
+                                "templateUrl": "app\/components\/form\/fields\/json.html",
+                                "defaultValue": null,
+                                "_previousName": "reason",
+                                "playbookField": true,
+                                "lengthConstraint": false,
+                                "allowedEncryption": true,
+                                "allowedGridColumn": false,
                                 "jinjaExpressionView": true,
                                 "useRecordFieldDefault": false
                             }
@@ -677,7 +687,7 @@
                 "input": {
                     "schema": {
                         "title": "Mark Alert as Phishing?",
-                        "description": "<p><strong><span style=\"text-decoration: underline;\">Investigation Summary</span></strong>:</p>\n<br>\n\n* {{vars.spf_check_message}}\n* {{vars.spoof_check_message}}\n* {{vars.suspicious_keyword_check_message}}\n{% if vars.drive_by_download_check_message %}* {{vars.drive_by_download_check_message}}{%endif%}\n* {{vars.malicious_indicator_check_message}}",
+                        "description": "<h6 class=\"text-underline\" style=\"margin: 0.5em 0 0.5em;\">Investigation Summary<\/h6>\n<br>\n\n* {{vars.spf_check_message}}\n* {{vars.spoof_check_message}}\n* {{vars.suspicious_keyword_check_message}}\n{% if vars.drive_by_download_check_message %}* {{vars.drive_by_download_check_message}}{%endif%}\n* {{vars.malicious_indicator_check_message}}",
                         "inputVariables": [
                             {
                                 "name": "reason",
@@ -766,13 +776,23 @@
                                 "name": "reason",
                                 "type": "string",
                                 "label": "Reason",
+                                "title": "Text Area",
+                                "usable": false,
                                 "tooltip": "The reason for categorizing this alert as a Drive-by Download",
                                 "dataType": "text",
-                                "formType": "text",
+                                "formType": "textarea",
                                 "required": true,
                                 "_expanded": true,
+                                "mmdUpdate": false,
+                                "collection": false,
+                                "searchable": false,
+                                "templateUrl": "app\/components\/form\/fields\/json.html",
                                 "defaultValue": null,
-                                "_previousName": "driveByDownloadReason",
+                                "_previousName": "reason",
+                                "playbookField": true,
+                                "lengthConstraint": false,
+                                "allowedEncryption": true,
+                                "allowedGridColumn": false,
                                 "jinjaExpressionView": true,
                                 "useRecordFieldDefault": false
                             }
@@ -862,7 +882,7 @@
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "alerts": "{{vars.input.records[0]['@id']}}",
                     "people": [],
-                    "content": "<p>- Request to block indicators is <span class=\"badge badge-success\" style=\"background: #28B35C; color: #fff;\">Approved<\/span><\/p>\n<p>- Proceeding with block procedure<\/p>",
+                    "content": "<p>- Request to block indicators is <span class=\"badge badge-success\" style=\"background: #28B35C; color: #fff; padding: 2px 7px;\">Approved<\/span><\/p>\n<p>- Proceeding with block procedure<\/p>",
                     "__replace": "",
                     "isImportant": false,
                     "peopleUpdated": false
@@ -892,7 +912,7 @@
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "alerts": "{{vars.input.records[0]['@id']}}",
                     "people": [],
-                    "content": "<p>Request to block indicators is <span class=\"badge badge-success\" style=\"background: #f0a313; color: black;\">Denied<\/span><\/p>",
+                    "content": "<p>Request to block indicators is <span class=\"badge badge-success\" style=\"background: #f0a313; color: black; padding: 2px 7px;\">Denied<\/span><\/p>",
                     "__replace": "",
                     "isImportant": false,
                     "peopleUpdated": false

--- a/playbooks/02 - Use Case - Phishing Email Response/URL > Remote Screenshot > Create and Link Attachment.json
+++ b/playbooks/02 - Use Case - Phishing Email Response/URL > Remote Screenshot > Create and Link Attachment.json
@@ -24,7 +24,7 @@
                 "alertUUID": "{{vars.input.records[0].uuid}}"
             },
             "status": null,
-            "top": "165",
+            "top": "300",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -38,7 +38,7 @@
                 "attachmentIRIList": "{{ vars.steps.Get_URL_Screenshot | json_query(\"[? attachmentIRI != None].attachmentIRI\") }}"
             },
             "status": null,
-            "top": "570",
+            "top": "705",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -81,7 +81,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "300",
+            "top": "435",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
@@ -108,7 +108,7 @@
                 "workflowReference": "\/api\/3\/workflows\/01acd03c-aaf1-4a79-b0b5-bddeb3a434a8"
             },
             "status": null,
-            "top": "435",
+            "top": "570",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -141,11 +141,30 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "a636af47-b974-45c5-a4fd-1fa025f4873f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "No Operation",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.2.6",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "77f1109b-018b-4ff9-ae08-6598c23b8511"
         },
         {
             "@type": "WorkflowStep",
@@ -214,10 +233,68 @@
             },
             "status": null,
             "top": "30",
-            "left": "125",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
             "uuid": "b3f4993c-22f9-424e-8dd8-b1d2294b7df5"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "URL Screenshot Confirmation",
+            "description": null,
+            "arguments": {
+                "type": "InputBased",
+                "input": {
+                    "schema": {
+                        "title": "URL Screenshot Confirmation",
+                        "description": "<span data-tomark-pass=\"\" style=\"font-size: 15px; color: #DE7A13;\" class=\"fa fa-exclamation-triangle\"><\/span>&nbsp;Warning: Taking screenshots of URLs may expose your system to potential security risks. Do you still want to proceed?\n&nbsp;\n**Note:** It is *highly recommended* to set up Remote Screenshot connector on the agent to access URLs securely. ",
+                        "inputVariables": []
+                    }
+                },
+                "record": "{{ vars.input.records[0][\"@id\"] }}",
+                "agent_id": null,
+                "resources": "alerts",
+                "is_approval": false,
+                "owner_detail": {
+                    "isAssigned": false,
+                    "emailRecipients": ""
+                },
+                "isRecordLinked": true,
+                "step_variables": [],
+                "response_mapping": {
+                    "options": [
+                        {
+                            "option": "Proceed",
+                            "primary": true,
+                            "step_iri": "\/api\/3\/workflow_steps\/72872980-7512-4335-b95d-eb6dead1e7ff"
+                        },
+                        {
+                            "option": "Cancel",
+                            "step_iri": "\/api\/3\/workflow_steps\/77f1109b-018b-4ff9-ae08-6598c23b8511"
+                        }
+                    ],
+                    "duplicateOption": false,
+                    "customSuccessMessage": "Awaiting Playbook resumed successfully."
+                },
+                "email_notification": {
+                    "enabled": false,
+                    "smtpParameters": []
+                },
+                "customEmailExternal": false,
+                "inline_channel_list": [],
+                "external_channel_list": [],
+                "unauthenticated_input": false,
+                "external_email_subject": null,
+                "internal_email_subject": "A FortiSOAR playbook is requesting your input",
+                "custom_email_body_external": null,
+                "external_email_attachments": null
+            },
+            "status": null,
+            "top": "165",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
+            "group": null,
+            "uuid": "09fcfa7d-b7c9-4f9c-a270-a222e65e3772"
         }
     ],
     "routes": [
@@ -263,13 +340,33 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/72872980-7512-4335-b95d-eb6dead1e7ff",
+            "name": "Start -> URL Screenshot Confirmation",
+            "targetStep": "\/api\/3\/workflow_steps\/09fcfa7d-b7c9-4f9c-a270-a222e65e3772",
             "sourceStep": "\/api\/3\/workflow_steps\/b3f4993c-22f9-424e-8dd8-b1d2294b7df5",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "3ef4d9c0-4d57-471f-a565-b87b25da21b2"
+            "uuid": "956dbd89-2210-4c2b-95e4-5eaa718ab0d0"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "URL Screenshot Confirmation -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/72872980-7512-4335-b95d-eb6dead1e7ff",
+            "sourceStep": "\/api\/3\/workflow_steps\/09fcfa7d-b7c9-4f9c-a270-a222e65e3772",
+            "label": "Proceed",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "dd8a8300-4233-469c-880e-4b2b087c9344"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "URL Screenshot Confirmation -> No Operation",
+            "targetStep": "\/api\/3\/workflow_steps\/77f1109b-018b-4ff9-ae08-6598c23b8511",
+            "sourceStep": "\/api\/3\/workflow_steps\/09fcfa7d-b7c9-4f9c-a270-a222e65e3772",
+            "label": "Cancel",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "16a083e5-a93e-4566-8db0-1e2bb98d5a2a"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - Phishing Email Response/URL > Remote Screenshot > Create and Link Attachment.json
+++ b/playbooks/02 - Use Case - Phishing Email Response/URL > Remote Screenshot > Create and Link Attachment.json
@@ -246,8 +246,8 @@
                 "type": "InputBased",
                 "input": {
                     "schema": {
-                        "title": "URL Screenshot Confirmation",
-                        "description": "<span data-tomark-pass=\"\" style=\"font-size: 15px; color: #DE7A13;\" class=\"fa fa-exclamation-triangle\"><\/span>&nbsp;Warning: Taking screenshots of URLs may expose your system to potential security risks. Do you still want to proceed?\n&nbsp;\n**Note:** It is *highly recommended* to set up Remote Screenshot connector on the agent to access URLs securely. ",
+                        "title": "Screenshot URL",
+                        "description": "<span data-tomark-pass=\"\" style=\"font-size: 15px; color: #DE7A13;\" class=\"fa fa-exclamation-triangle\"><\/span>&nbsp;Warning: Taking a screenshot of these *possibly malicious* URL may expose your system to security risks. Do you want to proceed?\n&nbsp;\n**Note:** We recommend setting up the [Remote Screenshot](https:\/\/fortisoar.contenthub.fortinet.com\/\/detail.html?entity=screenshot&version=1.0.0&type=connector) connector on the agent to securely access URLs. ",
                         "inputVariables": []
                     }
                 },


### PR DESCRIPTION
Implemented feedback-driven changes:

1. In 'URL > Remote Screenshot > Create and Link Attachment' playbook, added a manual confirmation step for taking URL screenshots.

2. In 'Investigate Suspicious Email' playbook:
   - Fixed color difference in SPF and Spoofing comment.
   - Updated heading format in 'Mark Alerts as Phishing' manual input step.
   - Modified field type to textarea in 'Drive by Download' and 'Close Alert' manual input steps for the *Reason* field.