### PR TITLE
Fix inline regex flag

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "phishingEmailResponse",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "type": "solutionpack",
     "local": true,
     "label": "Phishing Email Response",
@@ -22,7 +22,7 @@
     "certified": "true",
     "publisher": "Fortinet",
     "description": "Phishing Email Response Solution Pack is designed to provide a set of investigation and utility playbooks to respond to suspicious emails. These emails are typically reported by employees in the organization (sent to a SOC common email inbox).",
-    "help": "https://github.com/fortinet-fortisoar/solution-pack-phishing-email-response/blob/release/1.0.2/README.md",
+    "help": "https://github.com/fortinet-fortisoar/solution-pack-phishing-email-response/blob/release/1.0.3/README.md",
     "category": [],
     "featured": true,
     "supportInfo": "Fortinet Customer Support",

--- a/playbooks/02 - Use Case - Phishing Email Response/Investigate Suspicious Email.json
+++ b/playbooks/02 - Use Case - Phishing Email Response/Investigate Suspicious Email.json
@@ -1,5 +1,4 @@
 {
-    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "Investigate Suspicious Email",
@@ -531,8 +530,8 @@
             "name": "Get Non Permitted IP",
             "description": null,
             "arguments": {
-                "Not_Permitted_IPs_for_SPF_Fail": "{% for var in vars.SPF_Record if vars.SPF_Record %}{{\n    (var | regex_search('(?<=client-ip=)([\\S]*)(?=;)'))\n    if (var.startswith('fail') and var | regex_search('(?<=fail)([^,]+)(?i)'))\n}}{%endfor%}",
-                "Not_Permitted_IPs_for_SPF_SoftFail": "{% for var in vars.SPF_Record if vars.SPF_Record %}{{\n    (var | regex_search('(?<=client-ip=)([\\S]*)(?=;)'))\n    if (var.startswith('softfail') and var | regex_search('(?<=softfail)([^,]+)(?i)'))\n}}{%endfor%}"
+                "Not_Permitted_IPs_for_SPF_Fail": "{% for var in vars.SPF_Record if vars.SPF_Record %}{{ (var | regex_search('(?<=client-ip=)([\\\\S]*)(?=;)')) if (var.startswith('fail') and var | regex_search('(?i)(?<=fail)([^,]+)')) }}{% endfor %}",
+                "Not_Permitted_IPs_for_SPF_SoftFail": "{% for var in vars.SPF_Record if vars.SPF_Record %}{{ (var | regex_search('(?<=client-ip=)([\\\\S]*)(?=;)')) if (var.startswith('softfail') and var | regex_search('(?i)(?<=softfail)([^,]+)')) }}{% endfor %}"
             },
             "status": null,
             "top": "705",

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,24 +4,4 @@
 
 ### Investigate Suspicious Email
 
-- The playbook becomes visible and executable only for unresolved alerts of the type **_Suspicious Email_**.
-
-- *Suspicious Email* alerts found to be malicious (*true positive*) now have the **Email Classification** as *`Phishing`*.
-
-- *Manual Input* steps have refined descriptions to enhance understanding.
-
-    - A manual input, triggered by this playbook, displays the investigation summary and asks the users if the investigated alert is *`Phishing`* or *`False Positive`*.
-
-- The *Comments* have been improved for better readability and clarity.
-
-### Generate Phishing Email Alert
-
-- This playbook has been renamed to **Scenario - Generate Phishing Email Alert**.
-
-- Optimized the field mapping values on the sample record created.
-
-### URL > Remote Screenshot > Create and Link Attachment
-
-- A new playbook that captures screenshots of URL indicators, creates attachment records, and links them to the respective alert.
-
-    - For this, a new playbook **URL > Remote Screenshot > Get URL Screenshot** is triggered to capture screenshots of URL indicators linked to an alert of type **_Suspicious Email_**.
+- Updated the regex patterns to place inline flags at the start of the expression to ensure compatibility with Python 3.9, 3.10, 3.11 and 3.12.


### PR DESCRIPTION
- 0924234 | Fix inline regex flag compatibility issue for Python 3.12
   - RCA: After upgrading Python from 3.9 to 3.12, regex patterns containing inline flags such as (?i) started failing because newer Python versions enforce stricter regex validation. Inline flags are now required to be placed at the beginning of the regex expression.
   - Solution: Updated the regex patterns to place inline flags at the start of the expression to ensure compatibility with Python 3.9, 3.10, 3.11 and 3.12.